### PR TITLE
fix: Prevent keys with `undefined` from overriding model value

### DIFF
--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -23,11 +23,11 @@ describe('update', () => {
 
     realUpdate = await prisma.user.update({
       where: { email: seededUsers[0].email },
-      data: { warnings: 99 },
+      data: { warnings: 99, email: undefined },
     });
     mockUpdate = await prismock.user.update({
       where: { email: seededUsers[0].email },
-      data: { warnings: 99 },
+      data: { warnings: 99, email: undefined },
     });
   });
 
@@ -45,5 +45,12 @@ describe('update', () => {
 
     expect(formatEntries(stored)).toEqual(formatEntries(expectedStore));
     expect(formatEntries(mockStored)).toEqual(formatEntries(expectedStore));
+  });
+
+  it('Should not update keys with `undefined` as value', () => {
+    const expected = buildUser(1, { warnings: 99, email: seededUsers[0].email });
+
+    expect(formatEntry(realUpdate)).toEqual(formatEntry(expected));
+    expect(formatEntry(mockUpdate)).toEqual(formatEntry(expected));
   });
 });

--- a/src/lib/operations/update.ts
+++ b/src/lib/operations/update.ts
@@ -169,8 +169,14 @@ export function updateMany(args: UpdateArgs, current: Delegate, delegates: Deleg
       if (shouldUpdate) {
         const v = currentValue;
         const n = nestedUpdate(args, false, currentValue, current, delegates);
+        const sanitizedOverrides = Object.keys(n).reduce((acc, key) => {
+          if (typeof n[key] !== 'undefined') {
+            acc[key] = n[key];
+          }
+          return acc;
+        }, {} as Record<string, unknown>);
 
-        const updatedValue = { ...v, ...n };
+        const updatedValue = { ...v, ...sanitizedOverrides };
 
         return {
           toUpdate: [...accumulator.toUpdate, updatedValue],


### PR DESCRIPTION
Hey @morintd, great job with the lib!

I found a behavior that is currently broken when compared to Prisma's: when using [null or undefined](https://www.prisma.io/docs/concepts/components/prisma-client/null-and-undefined) to update a model, if you pass `name: undefined` to `prisma.model.update`, it's value should be ignored and don't update the current field value, but instead, I'm getting my properties overrided to `undefined`.

I prepared this small PR that fixes this behavior to match Prisma's more accurately