### PR TITLE
fix: 🐛 Correct Array.slice() with both skip + take

### DIFF
--- a/src/__tests__/find.test.ts
+++ b/src/__tests__/find.test.ts
@@ -211,6 +211,24 @@ describe('find', () => {
       expect(formatEntries(mockUsers)).toEqual(formatEntries(expected));
     });
 
+    it('Should return corresponding items with take and skip', async () => {
+      const expected = [seededUsers[1], seededUsers[2]];
+      const realUsers = await prisma.user.findMany({
+        where: {},
+        take: 2,
+        skip: 1,
+      });
+
+      const mockUsers = await prismock.user.findMany({
+        where: {},
+        take: 2,
+        skip: 1,
+      });
+
+      expect(formatEntries(realUsers)).toEqual(formatEntries(expected));
+      expect(formatEntries(mockUsers)).toEqual(formatEntries(expected));
+    });
+
     it("Should return empty list if doesn't exist", async () => {
       const realUser = await prisma.user.findMany({
         where: { email: 'user0@company.com' },

--- a/src/lib/operations/find/find.ts
+++ b/src/lib/operations/find/find.ts
@@ -32,7 +32,7 @@ export function where(whereArgs: FindArgs['where'] = {}, current: Delegate, dele
 
 export function paginate(items: Item[], skip?: number, take?: number) {
   if (!skip && !take) return items;
-  return items.slice(skip ?? 0, take);
+  return items.slice(skip ?? 0, take === undefined ? undefined : take + (skip ?? 0));
 }
 
 export function includes(args: FindArgs, current: Delegate, delegates: Delegates) {


### PR DESCRIPTION
Hi 👋🏻 Love your work on this!

Noticed a small bug when using both `skip` and `take`. The `Array.slice()` in `paginate()` needs to add the `skip`-value to the `take`-value.

Proposed fix in the PR, with added test.