### PR TITLE
Allow Synchronous Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,31 @@ beforeAll(async () => {
 
 Then, you will be able to write your tests as if your app was using an in-memory Prisma client.
 
+### Alternative Synchronous Client Generation
+
+You may have the option to generate the Prismock client synchronously if you have access to the DMMF (Datamodel Meta Format).
+
+```ts
+import { generatePrismockSync } from 'prismock';
+import { Prisma } from "__generated__/client";
+
+const models  = Prisma.dmmf.datamodel.models;
+
+let app: INestApplication;
+
+beforeAll(async () => {
+  const prismock = generatePrismockSync({ models });
+
+  const moduleRef = await Test.createTestingModule({ imports: [] })
+    .overrideProvider(PrismaService)
+    .useValue(prismock)
+    .compile();
+
+  app = moduleRef.createNestApplication();
+  await app.init();
+})
+```
+
 # API
 
 ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { generatePrismock } from './lib/prismock';
+export { generatePrismock, generatePrismockSync } from './lib/prismock';

--- a/src/lib/prismock.ts
+++ b/src/lib/prismock.ts
@@ -6,11 +6,12 @@ import { Generator, getDMMF, getGenerator, getSchemaSync } from '@prisma/interna
 
 import { isAutoIncrement } from './operations';
 import { Delegate, DelegateProperties, generateDelegate, Item } from './delegate';
-import { generateClient } from './client';
+import { generateClient, PrismockClient } from './client';
 import { camelize, omit } from './helpers';
 
 type Options = {
   schemaPath?: string;
+  models?: DMMF.Model[];
 };
 
 export type Data = Record<string, Item[]>;
@@ -34,10 +35,16 @@ export function getProvider(generator: Generator) {
   return generator.options?.datasources[0].activeProvider;
 }
 
-export async function generatePrismock<T = PrismaClient>(options: Options = {}) {
+export async function generatePrismock<T = PrismaClient>(options: Options = {}): Promise<PrismockClient<T>> {
+  if (options.models !== undefined && options.models.length > 0) {
+    return generatePrismockSync<T>(options);
+  }
   const schema = await generateDMMF(options.schemaPath);
-  const { models } = schema.datamodel;
+  return generatePrismockSync<T>({ models: schema.datamodel.models });
+}
 
+export function generatePrismockSync<T = PrismockClient>(options: Omit<Options, 'schemaPath'> = {}): PrismockClient<T> {
+  const models = options.models ?? [];
   const data: Data = {};
   const properties: Properties = {};
   const delegates: Delegates = {};


### PR DESCRIPTION
Addresses #329 

If the generated PrismaClient exposes the Datamodel Meta Format, allow users to supply the models directly, bypassing the async/await.