### PR TITLE
Add test for findFirst returning null

### DIFF
--- a/src/__tests__/find/find.test.ts
+++ b/src/__tests__/find/find.test.ts
@@ -8,6 +8,7 @@ import {
   isUUID,
   resetDb,
   seededBlogs,
+  seededPosts,
   seededUsers,
   simulateSeed,
 } from '../../../testing';
@@ -87,6 +88,29 @@ describe('find', () => {
 
       expect(formatEntry(realUser)).toEqual(formatEntry(expected));
       expect(formatEntry(mockUser)).toEqual(formatEntry(expected));
+    });
+
+    it('Should not return item', async () => {
+      const realPost = await prisma.post.findFirst({
+        where: {
+          id: seededPosts[1].id,
+          author: {
+            id: seededUsers[0].id,
+          },
+        },
+      });
+
+      const mockPost = await prismock.post.findFirst({
+        where: {
+          id: seededPosts[1].id,
+          author: {
+            id: seededUsers[0].id,
+          },
+        },
+      });
+
+      expect(realPost).toBeNull();
+      expect(mockPost).toBeNull();
     });
 
     it('Should return item with includes', async () => {


### PR DESCRIPTION
Hey, this test is actually falling, I tried my hardest to make it work but I don't understand fully the codebase.

```txt
    find › findFirst › Should not return item

    expect(received).toEqual(expected) // deep equality

    Expected: null
    Received: {"authorId": 2, "blogId": 2, "createdAt": 2024-01-09T18:59:57.960Z, "id": 2, "imprint": "3e937a1f-cd50-422f-bd0d-624d9ccd441d", "title": "title2"}

      111 |
      112 |       expect(realPost).toEqual(null);
    > 113 |       expect(mockPost).toEqual(null);
          |                        ^
      114 |     });
```

I think the issue is somewhere near https://github.com/morintd/prismock/blob/3e74dd216317013334b1ca799c504f9bca7ca636/src/lib/operations/find/match.ts#L77

Changing the output of [getFieldRelationshipWhere](https://github.com/morintd/prismock/blob/3e74dd216317013334b1ca799c504f9bca7ca636/src/lib/operations/find/find.ts#L209) to:

```ts
export const getFieldRelationshipWhere = (
  item: Item,
  field: DMMF.Field,
  delegates: Delegates,
): Record<string, GroupByFieldArg> => {
  if (field.relationToFields?.length === 0) {
    field = getJoinField(field, delegates)!;
    return {
      [field.relationFromFields![0]]: item[field.relationToFields![0]] as GroupByFieldArg,
    };
  }
  return {
    [field.relationFromFields![0]]: item[field.relationToFields![0]] as GroupByFieldArg,
  };
};
```
made my new test pass but broke `find-nested.test.ts` and some other tests, with this change https://github.com/morintd/prismock/blob/3e74dd216317013334b1ca799c504f9bca7ca636/src/lib/operations/find/match.ts#L79

returns `{ id: 1, authorId: 2 }`, without the change it returns only `{ id : 2 }` because `getFieldRelationshipWhere` overrides the `Object.assign({}, childWhere)` since it's the same key **id**.

@morintd if you have some idea on how to fix the nested find now, I would love to submit it into this PR