### PR TITLE
fix: bug in scalar list push support that would push the push function of arrays onto each array

### DIFF
--- a/src/lib/operations/update.ts
+++ b/src/lib/operations/update.ts
@@ -176,15 +176,16 @@ const update = (args: UpdateArgs, isCreating: boolean, item: Item, current: Dele
             }
           }
         }
-      } else if (field.kind === 'scalar') {
-        if (field.isList) {
-          if (fieldData.push && typeof fieldData.push !== 'function') {
-            if (Array.isArray(fieldData.push))
-              Object.assign(data, { [field.name]: (item[field.name] as Array<unknown>).concat(fieldData.push) });
-            else Object.assign(data, { [field.name]: (item[field.name] as Array<unknown>).concat([fieldData.push]) });
-          }
+      }
+
+      if (field.isList) {
+        if (fieldData.push && typeof fieldData.push !== 'function') {
+          if (Array.isArray(fieldData.push))
+            Object.assign(data, { [field.name]: (item[field.name] as Array<unknown>).concat(fieldData.push) });
+          else Object.assign(data, { [field.name]: (item[field.name] as Array<unknown>).concat([fieldData.push]) });
         }
       }
+
       if (fieldData.increment) {
         Object.assign(data, { [field.name]: (item[field.name] as number) + (fieldData.increment as number) });
       }

--- a/src/lib/operations/update.ts
+++ b/src/lib/operations/update.ts
@@ -178,7 +178,7 @@ const update = (args: UpdateArgs, isCreating: boolean, item: Item, current: Dele
         }
       } else if (field.kind === 'scalar') {
         if (field.isList) {
-          if (fieldData.push) {
+          if (fieldData.push && typeof fieldData.push !== 'function') {
             if (Array.isArray(fieldData.push))
               Object.assign(data, { [field.name]: (item[field.name] as Array<unknown>).concat(fieldData.push) });
             else Object.assign(data, { [field.name]: (item[field.name] as Array<unknown>).concat([fieldData.push]) });


### PR DESCRIPTION
The current code trips on things like:
```typescript
this.prisma.someModel.update({
  where: { id },
  data: {
    someList: ["a", "b", "c"],
  },
})
```
Since the array `["a", "b", "c"]` itself has a push function, it would push the push function itself into the array and insert it into the DB.

Sorry for causing this bug. Can you please add a test?