### PR TITLE
Fix: Consider `uuid()` new Prisma type when creating default value for UUID fields

### DIFF
--- a/src/lib/operations/create.ts
+++ b/src/lib/operations/create.ts
@@ -39,7 +39,7 @@ const defaultFieldhandlers: [
     },
   ],
   [
-    (field: DMMF.Field) => (field.default as DMMF.FieldDefault)?.name === 'uuid',
+    (field: DMMF.Field) => (field.default as DMMF.FieldDefault)?.name?.includes('uuid'),
     () => {
       return uuid();
     },


### PR DESCRIPTION
Since Prisma 5.18.0 release, a new support for UUIDv7 was introduced.

This caused a [breaking change](https://github.com/prisma/prisma/releases/tag/5.18.0#:~:text=Native%20support%20for%20UUIDv7) that would cause former field type `uuid` to be either `uuid()` or `uuid(4)` or `uuid(7)`.

This Pull Request gives some support to the new field type.

Fixes #1081 