### PR TITLE
fix: compound id issue with default name

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   profile       Profile?
   service       Service[]
   subscriptions Subscription[]
+  Reaction      Reaction[]
 }
 
 model Profile {
@@ -89,4 +90,14 @@ model Subscription {
 
   blog   Blog @relation(fields: [blogId], references: [id])
   blogId Int
+}
+
+model Reaction {
+  userId Int
+  emoji  String
+  value  Int
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@id([userId, emoji])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,7 +32,7 @@ model User {
   profile       Profile?
   service       Service[]
   subscriptions Subscription[]
-  Reaction      Reaction[]
+  reactions     Reaction[]
 }
 
 model Profile {

--- a/src/__tests__/client/client-custom.test.ts
+++ b/src/__tests__/client/client-custom.test.ts
@@ -20,10 +20,7 @@ describe('client (custom)', () => {
 
       const data = prismock.getData();
 
-      expect({
-        ...data,
-        user: data.user.map(({ id, ...user }) => user),
-      }).toEqual({
+      const expected = {
         user: seededUsers.map(({ id, ...user }) => user),
         blog: [],
         post: [],
@@ -31,7 +28,18 @@ describe('client (custom)', () => {
         reaction: [],
         service: [],
         subscription: [],
-      });
+      };
+
+      if (provider !== 'mongodb') {
+        Object.assign(expected, {
+          reaction: [],
+        });
+      }
+
+      expect({
+        ...data,
+        user: data.user.map(({ id, ...user }) => user),
+      }).toEqual(expected);
     });
   });
 

--- a/src/__tests__/client/client-custom.test.ts
+++ b/src/__tests__/client/client-custom.test.ts
@@ -1,10 +1,18 @@
 import { DMMF } from '@prisma/generator-helper';
 
 import { seededUsers } from '../../../testing';
-import { generateDMMF, generatePrismockSync } from '../../lib/prismock';
+import { fetchGenerator, generateDMMF, generatePrismockSync, getProvider } from '../../lib/prismock';
 import { PrismockClient, PrismockClientType } from '../../lib/client';
 
 describe('client (custom)', () => {
+  let provider: string | undefined;
+
+  beforeAll(async () => {
+    const generator = await fetchGenerator();
+    provider = getProvider(generator);
+    generator.stop();
+  });
+
   describe('generatePrismock', () => {
     it('Should get data', async () => {
       const prismock = new PrismockClient() as PrismockClientType;
@@ -41,18 +49,25 @@ describe('client (custom)', () => {
 
       const data = prismock.getData();
 
-      expect({
-        ...data,
-        user: data.user.map(({ id, ...user }) => user),
-      }).toEqual({
+      const expected = {
         user: seededUsers.map(({ id, ...user }) => user),
         blog: [],
         post: [],
         profile: [],
-        reaction: [],
         service: [],
         subscription: [],
-      });
+      };
+
+      if (provider !== 'mongodb') {
+        Object.assign(expected, {
+          reaction: [],
+        });
+      }
+
+      expect({
+        ...data,
+        user: data.user.map(({ id, ...user }) => user),
+      }).toEqual(expected);
     });
   });
 });

--- a/src/__tests__/client/client-custom.test.ts
+++ b/src/__tests__/client/client-custom.test.ts
@@ -25,7 +25,6 @@ describe('client (custom)', () => {
         blog: [],
         post: [],
         profile: [],
-        reaction: [],
         service: [],
         subscription: [],
       };

--- a/src/__tests__/client/client-custom.test.ts
+++ b/src/__tests__/client/client-custom.test.ts
@@ -20,6 +20,7 @@ describe('client (custom)', () => {
         blog: [],
         post: [],
         profile: [],
+        reaction: [],
         service: [],
         subscription: [],
       });
@@ -48,6 +49,7 @@ describe('client (custom)', () => {
         blog: [],
         post: [],
         profile: [],
+        reaction: [],
         service: [],
         subscription: [],
       });

--- a/src/__tests__/find/find-unique.test.ts
+++ b/src/__tests__/find/find-unique.test.ts
@@ -3,7 +3,7 @@
 // @ts-nocheck
 import { PrismaClient, User } from '@prisma/client';
 
-import { resetDb, seededUsers, simulateSeed, seededBlogs, seededServices } from '../../../testing';
+import { resetDb, seededUsers, simulateSeed, seededBlogs, seededServices, seededReactions } from '../../../testing';
 import { PrismockClient, PrismockClientType } from '../../lib/client';
 import { fetchGenerator, getProvider } from '../../lib/prismock';
 
@@ -56,6 +56,21 @@ describe('find', () => {
         const mockService = (await prismock.service.findUnique({
           where: { compositeId: { name: expected.name, userId: expected.userId } },
         }))!;
+
+        expect(realService).toEqual(expected);
+        expect(mockService).toEqual(expected);
+      }
+    });
+
+    it('Should return corresponding item based on @@id with default name', async () => {
+      if (provider !== 'mongodb') {
+        const expected = seededReactions[0];
+        const realService = await prisma.reaction.findUnique({
+          where: { userId_emoji: { userId: expected.userId, emoji: expected.emoji } },
+        });
+        const mockService = await prismock.reaction.findUnique({
+          where: { userId_emoji: { userId: expected.userId, emoji: expected.emoji } },
+        });
 
         expect(realService).toEqual(expected);
         expect(mockService).toEqual(expected);

--- a/src/__tests__/update/update-many.test.ts
+++ b/src/__tests__/update/update-many.test.ts
@@ -3,7 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import { resetDb, simulateSeed, buildUser, formatEntries, generateId } from '../../../testing';
 import { PrismockClient, PrismockClientType } from '../../lib/client';
 
-jest.setTimeout(15000);
+jest.setTimeout(40000);
 
 describe('updateMany', () => {
   let prismock: PrismockClientType;

--- a/src/__tests__/update/update.test.ts
+++ b/src/__tests__/update/update.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable jest/no-conditional-expect */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
@@ -122,11 +123,12 @@ describe('update', () => {
   });
 
   describe('Update using compound id with default name', () => {
-    const updatedReaction = seededReactions[0];
-    const untouchedReaction = seededReactions[1];
     const expectedNewValue = 100;
 
     beforeAll(async () => {
+      const updatedReaction = seededReactions[0];
+      const untouchedReaction = seededReactions[1];
+
       if (provider !== 'mongodb') {
         await prisma.reaction.update({
           where: {
@@ -155,6 +157,9 @@ describe('update', () => {
 
     it('Should update expected entry', async () => {
       if (provider !== 'mongodb') {
+        const updatedReaction = seededReactions[0];
+        const untouchedReaction = seededReactions[1];
+
         const realResult = await prisma.reaction.findUnique({
           where: {
             userId_emoji: {
@@ -174,10 +179,15 @@ describe('update', () => {
 
         expect(realResult.value).toEqual(expectedNewValue);
         expect(mockResult.value).toEqual(expectedNewValue);
+      } else {
+        console.log('[SKIPPED] compound ID not supported on MongoDB');
       }
     });
 
     it('Should not update other data', async () => {
+      const updatedReaction = seededReactions[0];
+      const untouchedReaction = seededReactions[1];
+
       if (provider !== 'mongodb') {
         const realResult = await prisma.reaction.findUnique({
           where: {
@@ -198,6 +208,8 @@ describe('update', () => {
 
         expect(realResult.value).toEqual(untouchedReaction.value);
         expect(mockResult.value).toEqual(untouchedReaction.value);
+      } else {
+        console.log('[SKIPPED] compound ID not supported on MongoDB');
       }
     });
   });

--- a/src/__tests__/update/update.test.ts
+++ b/src/__tests__/update/update.test.ts
@@ -126,10 +126,10 @@ describe('update', () => {
     const expectedNewValue = 100;
 
     beforeAll(async () => {
-      const updatedReaction = seededReactions[0];
-      const untouchedReaction = seededReactions[1];
-
       if (provider !== 'mongodb') {
+        const updatedReaction = seededReactions[0];
+        const untouchedReaction = seededReactions[1];
+
         await prisma.reaction.update({
           where: {
             userId_emoji: {

--- a/src/__tests__/update/update.test.ts
+++ b/src/__tests__/update/update.test.ts
@@ -185,10 +185,10 @@ describe('update', () => {
     });
 
     it('Should not update other data', async () => {
-      const updatedReaction = seededReactions[0];
-      const untouchedReaction = seededReactions[1];
-
       if (provider !== 'mongodb') {
+        const updatedReaction = seededReactions[0];
+        const untouchedReaction = seededReactions[1];
+
         const realResult = await prisma.reaction.findUnique({
           where: {
             userId_emoji: {

--- a/src/__tests__/update/update.test.ts
+++ b/src/__tests__/update/update.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-conditional-expect */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 import { PrismaClient, Service } from '@prisma/client';
@@ -121,12 +122,12 @@ describe('update', () => {
   });
 
   describe('Update using compound id with default name', () => {
-    if (provider !== 'mongodb') {
-      const updatedReaction = seededReactions[0];
-      const untouchedReaction = seededReactions[1];
-      const expectedNewValue = 100;
+    const updatedReaction = seededReactions[0];
+    const untouchedReaction = seededReactions[1];
+    const expectedNewValue = 100;
 
-      beforeAll(async () => {
+    beforeAll(async () => {
+      if (provider !== 'mongodb') {
         await prisma.reaction.update({
           where: {
             userId_emoji: {
@@ -149,9 +150,11 @@ describe('update', () => {
             value: expectedNewValue,
           },
         });
-      });
+      }
+    });
 
-      it('Should update expected entry', async () => {
+    it('Should update expected entry', async () => {
+      if (provider !== 'mongodb') {
         const realResult = await prisma.reaction.findUnique({
           where: {
             userId_emoji: {
@@ -171,9 +174,11 @@ describe('update', () => {
 
         expect(realResult.value).toEqual(expectedNewValue);
         expect(mockResult.value).toEqual(expectedNewValue);
-      });
+      }
+    });
 
-      it('Should not update other data', async () => {
+    it('Should not update other data', async () => {
+      if (provider !== 'mongodb') {
         const realResult = await prisma.reaction.findUnique({
           where: {
             userId_emoji: {
@@ -193,7 +198,7 @@ describe('update', () => {
 
         expect(realResult.value).toEqual(untouchedReaction.value);
         expect(mockResult.value).toEqual(untouchedReaction.value);
-      });
-    }
+      }
+    });
   });
 });

--- a/src/lib/operations/find/match.ts
+++ b/src/lib/operations/find/match.ts
@@ -121,7 +121,10 @@ export const matchMultiple = (item: Item, where: FindWhereArgs, current: Delegat
         }
 
         const compositeIndex =
-          current.model.uniqueIndexes.map((index) => index.name).includes(child) || current.model.primaryKey?.name === child;
+          current.model.uniqueIndexes.map((index) => index.name).includes(child) ||
+          current.model.primaryKey?.name === child ||
+          current.model.primaryKey?.fields.join('_');
+
         if (compositeIndex) {
           return matchMultiple(item, where[child] as FindWhereArgs, current, delegates);
         }

--- a/testing/index.ts
+++ b/testing/index.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 
-import { Blog, Post, PrismaClient, Role, Service, Subscription, User } from '@prisma/client';
+import { Blog, Post, PrismaClient, Reaction, Role, Service, Subscription, User } from '@prisma/client';
 import dotenv from 'dotenv';
 import { createId } from '@paralleldrive/cuid2';
 
@@ -10,6 +10,10 @@ export const seededUsers = [buildUser(1), buildUser(2, { warnings: 5 }), buildUs
 export const seededBlogs = [buildBlog(1, { title: 'blog-1' }), buildBlog(2, { title: 'blog-2', userId: seededUsers[0].id })];
 export const seededPosts = [buildPost(1, { authorId: 1, blogId: 1 }), buildPost(2, { authorId: 2, blogId: 2 })];
 export const seededServices = [buildService({ userId: 1, name: 'facebook' })];
+export const seededReactions = [
+  buildReaction({ userId: 1, emoji: 'thumbsup' }),
+  buildReaction({ userId: 1, emoji: 'rocket' }),
+];
 
 export async function simulateSeed(prisma: PrismaClient) {
   await prisma.user.createMany({ data: seededUsers.map(({ id, ...user }) => user) });
@@ -18,6 +22,7 @@ export async function simulateSeed(prisma: PrismaClient) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore MySQL / Tags
   await prisma.service.createMany({ data: seededServices });
+  await prisma.reaction.createMany({ data: seededReactions });
 }
 
 export async function resetDb() {
@@ -82,6 +87,15 @@ export function buildSubscription(id: number, subscription: Partial<Subscription
   return {
     id,
     ...subscription,
+  };
+}
+
+export function buildReaction(reaction: Pick<Reaction, 'userId' | 'emoji'>) {
+  const { userId, emoji } = reaction;
+  return {
+    userId,
+    emoji,
+    value: 0,
   };
 }
 

--- a/testing/mysql/schema.prisma
+++ b/testing/mysql/schema.prisma
@@ -32,6 +32,7 @@ model User {
   profile       Profile?
   service       Service[]
   subscriptions Subscription[]
+  reactions     Reaction[]
 }
 
 model Profile {
@@ -89,4 +90,14 @@ model Subscription {
 
   blog   Blog @relation(fields: [blogId], references: [id])
   blogId Int
+}
+
+model Reaction {
+  userId Int
+  emoji  String
+  value  Int
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@id([userId, emoji])
 }


### PR DESCRIPTION
Encountered an issue where `update()` and `findUnique()` were misbehaving when the underlying compound id wasn't explicitly given a name.

This PR adds a test for this case and includes the fix for it.