### PR TITLE
feat: support dbgenerated id type

### DIFF
--- a/src/lib/operations/create.ts
+++ b/src/lib/operations/create.ts
@@ -56,6 +56,12 @@ const defaultFieldhandlers: [
       return createCuid();
     },
   ],
+  [
+    (field: DMMF.Field) => (field.default as DMMF.FieldDefault)?.name === 'dbgenerated',
+    () => {
+      return uuid();
+    },
+  ],
 ];
 
 export function calculateDefaultFieldValue(field: DMMF.Field, properties: DelegateProperties) {


### PR DESCRIPTION
This enables the support to have `dbgenerated()` ids in your schema and still be able to use prismock to create entries without explicitly passing the id.

Previously, in a schema file with ids defined like this:
```
model Thing {
  id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
  ...
 ```
 Calling `prismock.thing.create()` would result in a object with an undefined `id`.
 