### PR TITLE
fix: reset reference to get and set data

### DIFF
--- a/src/__tests__/client/reset.test.ts
+++ b/src/__tests__/client/reset.test.ts
@@ -30,5 +30,8 @@ describe('client (reset)', () => {
 
     const usersAfterReset = await userService.findMany();
     expect(usersAfterReset.length > 0).not.toBeTruthy();
+
+    const getDataUsers = prismock.getData().user;
+    expect(getDataUsers.length > 0).not.toBeTruthy();
   });
 });

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -66,10 +66,13 @@ export function createPrismock(instance: PrismaModule) {
     private generate() {
       const { delegates, setData, getData } = generateDelegates({ models: instance.dmmf.datamodel.models as DMMF.Model[] });
 
-      Object.entries({ ...delegates, setData, getData }).forEach(([key, value]) => {
+      Object.entries({ ...delegates }).forEach(([key, value]) => {
         if (key in this) Object.assign((this as unknown as Delegates)[key], value);
         else Object.assign(this, { [key]: value });
       });
+
+      (this as unknown as typeof PrismaClient & PrismockData).getData = getData;
+      (this as unknown as typeof PrismaClient & PrismockData).setData = setData;
     }
 
     async $connect() {


### PR DESCRIPTION
This fix addresses a reference issue with `getData` and `setData` during `reset` operations. 
Previously, after a `reset`, `getData` would continue returning stale data because it maintained a reference to the old data object. 

This occurred because Object.assign does not update the execution context of copied functions. The function reference remained bound to the original data even after resetting.


Here's a quick example of the problem.
```
function func (newData) {

   const data = newData;
  
  function nestedFunc() {
    console.log(data);
  }

  return {nestedFunc};
}

const a = func("original data");
const b = func("new data");

a.nestedFunc(); // "original data"

Object.assign(a.nestedFunc, b.nestedFunc);

a.nestedFunc(); // "original data"
```
https://jsbin.com/huwataloru/edit?js,console
