### PR TITLE
fix: matching for models with a composite primary key

### DIFF
--- a/src/__tests__/find/find-many.test.ts
+++ b/src/__tests__/find/find-many.test.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable jest/no-conditional-expect */
+// @ts-nocheck
+import { PrismaClient, User } from '@prisma/client';
+
+import { resetDb, seededUsers, simulateSeed, seededBlogs, seededServices, seededReactions } from '../../../testing';
+import { PrismockClient, PrismockClientType } from '../../lib/client';
+import { fetchGenerator, getProvider } from '../../lib/prismock';
+
+jest.setTimeout(40000);
+
+describe('find', () => {
+  let prismock: PrismockClientType;
+  let prisma: PrismaClient;
+
+  let realUser: User;
+  let mockUser: User;
+
+  let provider: string;
+
+  beforeAll(async () => {
+    await resetDb();
+
+    prisma = new PrismaClient();
+    prismock = new PrismockClient() as PrismockClientType;
+    await simulateSeed(prismock);
+
+    const generator = await fetchGenerator();
+    provider = getProvider(generator)!;
+    generator.stop();
+  });
+
+  describe('findMany', () => {
+    it('Should find the single item matching the composite primary key', async () => {
+      const expected = seededServices[0];
+      const realServices = (await prisma.service.findMany({
+        where: { name: { equals: expected.name }, userId: { equals: expected.userId } },
+      }))!;
+      const mockServices = (await prismock.service.findMany({
+        where: { name: { equals: expected.name }, userId: { equals: expected.userId } },
+      }))!;
+
+      expect(realServices.length).toEqual(1);
+      expect(realServices[0]).toEqual(expected);
+      expect(mockServices).toEqual(realServices);
+    });
+  });
+});

--- a/src/lib/operations/find/match.ts
+++ b/src/lib/operations/find/match.ts
@@ -123,7 +123,7 @@ export const matchMultiple = (item: Item, where: FindWhereArgs, current: Delegat
         const compositeIndex =
           current.model.uniqueIndexes.map((index) => index.name).includes(child) ||
           current.model.primaryKey?.name === child ||
-          current.model.primaryKey?.fields.join('_');
+          current.model.primaryKey?.fields.join('_') === child;
 
         if (compositeIndex) {
           return matchMultiple(item, where[child] as FindWhereArgs, current, delegates);


### PR DESCRIPTION
This is a fix for https://github.com/morintd/prismock/issues/1263

Models with composite primary keys had their match functionality broken in 1.35.