### PR TITLE
Support `nanoid` default id type

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "@paralleldrive/cuid2": "2.2.2",
     "@prisma/generator-helper": "5.22.0",
     "@prisma/internals": "5.22.0",
-    "bson": "6.10.3"
+    "bson": "6.10.3",
+    "nanoid": "^3.3.11"
   },
   "peerDependencies": {
     "@prisma/client": "*",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,7 +36,7 @@ model User {
 }
 
 model Profile {
-  id     Int     @id @default(autoincrement())
+  id     String  @id @default(nanoid())
   bio    String?
   gender Gender
   user   User    @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/__tests__/create/create.test.ts
+++ b/src/__tests__/create/create.test.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Role, User } from '@prisma/client';
+import { Gender, PrismaClient, Profile, Role, User } from '@prisma/client';
 
 import {
   buildUser,
@@ -22,6 +22,8 @@ describe('create', () => {
 
   const mockUsers: User[] = [];
   const realUsers: User[] = [];
+  const mockProfiles: Profile[] = [];
+  const realProfiles: Profile[] = [];
 
   const data = {
     user1: { email: 'user4@company.com', password: 'password', warnings: 0 },
@@ -39,6 +41,7 @@ describe('create', () => {
     },
     user4: { email: 'user-many-1@company.com', password: 'password', warnings: 0, birthday: new Date('01-01-1971') },
     user5: { email: 'user-many-2@company.com', password: 'password', warnings: 0, birthday: new Date('12-12-2012') },
+    profile1: { bio: 'User 1 profile', gender: Gender.FEMALE, userId: 1 },
   };
 
   beforeAll(async () => {
@@ -51,10 +54,12 @@ describe('create', () => {
     mockUsers.push(await prismock.user.create({ data: data.user1 }));
     mockUsers.push(await prismock.user.create({ data: data.user2 }));
     mockUsers.push(await prismock.user.create({ data: data.user3 }));
+    mockProfiles.push(await prismock.profile.create({ data: data.profile1 }));
 
     realUsers.push(await prisma.user.create({ data: data.user1 }));
     realUsers.push(await prisma.user.create({ data: data.user2 }));
     realUsers.push(await prisma.user.create({ data: data.user3 }));
+    realProfiles.push(await prisma.profile.create({ data: data.profile1 }));
   });
 
   describe('create', () => {
@@ -91,6 +96,13 @@ describe('create', () => {
 
       expect(formatEntry(realUsers[1])).toEqual(formatEntry(expected));
       expect(formatEntry(mockUsers[1])).toEqual(formatEntry(expected));
+    });
+
+    it('Should create with nanoid', () => {
+      const nanoidRegex = /^[a-zA-Z0-9_-]{21}$/;
+
+      expect(realProfiles[0].id).toMatch(nanoidRegex);
+      expect(mockProfiles[0].id).toMatch(nanoidRegex);
     });
 
     it('Should creat with default cuid value', async () => {

--- a/src/lib/operations/create.ts
+++ b/src/lib/operations/create.ts
@@ -2,6 +2,7 @@ import { Decimal } from '@prisma/client/runtime/library';
 import { DMMF } from '@prisma/generator-helper';
 import { ObjectId } from 'bson';
 import { createId as createCuid } from '@paralleldrive/cuid2';
+import { nanoid } from 'nanoid';
 
 import { Delegate, DelegateProperties, Item } from '../delegate';
 import { pipe, removeUndefined, uuid } from '../helpers';
@@ -42,6 +43,12 @@ const defaultFieldhandlers: [
     (field: DMMF.Field) => (field.default as DMMF.FieldDefault)?.name?.includes('uuid'),
     () => {
       return uuid();
+    },
+  ],
+  [
+    (field: DMMF.Field) => (field.default as DMMF.FieldDefault)?.name?.startsWith('nanoid'),
+    (_properties: DelegateProperties, _field: DMMF.Field) => {
+      return nanoid();
     },
   ],
   [


### PR DESCRIPTION
I went ahead and implemented `nanoid` support in a forked version because we need it in a project, but would love to have that included in the official version.

A couple of comments:
- I used `nanoid` v3, because the newer versions require ESM. I still think this should be good enough for mocking purposes.
- I altered the `Profile` model to have `Id String @id @default(nanoid())`, to be able to test this. The id of this model was not used in any tests, so it had minimal impact on other tests and the general setup.