### PR TITLE
Fix: Support composite foreign keys in cascade delete operations - Update find.ts

### DIFF
--- a/src/lib/operations/find/find.ts
+++ b/src/lib/operations/find/find.ts
@@ -229,25 +229,45 @@ export const getFieldRelationshipWhere = (
 ): Record<string, GroupByFieldArg> => {
   if (field.relationToFields?.length === 0) {
     field = getJoinField(field, delegates)!;
-    return {
-      [field.relationFromFields![0]]: item[field.relationToFields![0]] as GroupByFieldArg,
-    };
+    if (!field.relationFromFields || !field.relationToFields) return {};
+    const result: Record<string, GroupByFieldArg> = {};
+    for (let i = 0; i < field.relationFromFields.length; i++) {
+      const from = field.relationFromFields[i];
+      const to = field.relationToFields[i];
+      result[from] = item[to] as GroupByFieldArg;
+    }
+    return result;
   }
-  return {
-    [field.relationToFields![0]]: item[field.relationFromFields![0]] as GroupByFieldArg,
-  };
+  if (!field.relationToFields || !field.relationFromFields) return {};
+  const result: Record<string, GroupByFieldArg> = {};
+  for (let i = 0; i < field.relationToFields.length; i++) {
+    const to = field.relationToFields[i];
+    const from = field.relationFromFields[i];
+    result[to] = item[from] as GroupByFieldArg;
+  }
+  return result;
 };
 
 export const getFieldFromRelationshipWhere = (item: Item, field: DMMF.Field) => {
-  return {
-    [field.relationFromFields![0]]: item[field.relationToFields![0]] as GroupByFieldArg,
-  };
+  if (!field.relationFromFields || !field.relationToFields) return {};
+  const result: Record<string, GroupByFieldArg> = {};
+  for (let i = 0; i < field.relationFromFields.length; i++) {
+    const from = field.relationFromFields[i];
+    const to = field.relationToFields[i];
+    result[from] = item[to] as GroupByFieldArg;
+  }
+  return result;
 };
 
 export const getFieldToRelationshipWhere = (item: Item, field: DMMF.Field) => {
-  return {
-    [field.relationToFields![0]]: item[field.relationFromFields![0]] as GroupByFieldArg,
-  };
+  if (!field.relationToFields || !field.relationFromFields) return {};
+  const result: Record<string, GroupByFieldArg> = {};
+  for (let i = 0; i < field.relationToFields.length; i++) {
+    const to = field.relationToFields[i];
+    const from = field.relationFromFields[i];
+    result[to] = item[from] as GroupByFieldArg;
+  }
+  return result;
 };
 
 function connect(args: FindArgs, current: Delegate, delegates: Delegates) {


### PR DESCRIPTION
GH-1496 : fix: support composite foreign keys in cascade delete operations

- Fixed getFieldFromRelationshipWhere to iterate over all FK columns
- Fixed getFieldRelationshipWhere to handle all composite key columns
- Fixed getFieldToRelationshipWhere for completeness
- Previously only the first column was checked, causing over-broad cascades
- Now all columns in relationFromFields/relationToFields are used
- Prevents unintended deletion of child rows with matching first FK column

Fixes composite foreign key cascade behavior to match real database operations